### PR TITLE
Recursive to queue search

### DIFF
--- a/Fuzzy Logic Chess/Assets/Scripts/Block.cs
+++ b/Fuzzy Logic Chess/Assets/Scripts/Block.cs
@@ -6,6 +6,8 @@ public class Block : MonoBehaviour
 
     public Color initial_color;
     private Color current_color;
+    private bool movable = false;
+    private bool visited = false;
 
     // Position.
     public void SetPosition(int row, int column)
@@ -40,5 +42,21 @@ public class Block : MonoBehaviour
     {
         GetComponent<SpriteRenderer>().material.color = initial_color;
         current_color = initial_color;
+    }
+    public bool IsVisited()
+    {
+        return visited;
+    }
+    public void SetVisited(bool b)
+    {
+        visited = b;
+    }
+    public bool IsMovable()
+    {
+        return movable;
+    }
+    public void SetMovable(bool b)
+    {
+        movable = b;
     }
 }

--- a/Fuzzy Logic Chess/Assets/Scripts/BoardManager.cs
+++ b/Fuzzy Logic Chess/Assets/Scripts/BoardManager.cs
@@ -216,11 +216,11 @@ public class BoardManager : MonoBehaviour
                         selected_index = index;
                         selected_piece = active_pieces[index[0], index[1]].GetComponent<Piece>();
                         // list of coordinates of movable blocks
-                        List<int[]> availableMoves = GetMovesList(index[0], index[1], selected_piece.GetNumberOfMoves()); 
-                        RecolorBlockList(availableMoves);
+                        List<int[]> availableMoves = GetMovesList(index[0], index[1], selected_piece.GetNumberOfMoves());
+                        SetBlockListMovable(availableMoves);
                     }
                     // clickable if empty and is within range
-                    else if (selected_index[0] >= 0 && selected_index[1] >= 0 && blocks[index[0], index[1]].GetComponent<Block>().IsMovable()) 
+                    else if (selected_index[0] >= 0 && selected_index[1] >= 0 && blocks[index[0], index[1]].GetComponent<Block>().IsMovable())
                     {
                         RefreshBlocks();
                         MovePiece(selected_index, block.GetPosition());
@@ -257,7 +257,8 @@ public class BoardManager : MonoBehaviour
     {
         Queue<int[]> buildQueue = new Queue<int[]>();
         Queue<int[]> currentQueue = new Queue<int[]>();
-        do {
+        do
+        {
 
             /* NOTE: If you can express the validation for the adjacent blocks better
              * or more optimized, please feel free.  All adjacent blocks needs to be 
@@ -268,17 +269,17 @@ public class BoardManager : MonoBehaviour
             {
                 if (IsValidBlock(row + 1, col)) // Down
                 {
-                  //  ProcessBlock(row + 1, col, list);
+                    ProcessBlock(row + 1, col, list);
                     buildQueue.Enqueue(new int[2] { row + 1, col });
                 }
                 if (col < 7 && IsValidBlock(row + 1, col + 1)) // Down Right
                 {
-                 //   ProcessBlock(row + 1, col + 1, list);
+                    ProcessBlock(row + 1, col + 1, list);
                     buildQueue.Enqueue(new int[2] { row + 1, col + 1 });
                 }
                 if (col > 0 && IsValidBlock(row + 1, col - 1)) // Down Left
                 {
-                   // ProcessBlock(row + 1, col - 1, list);
+                    ProcessBlock(row + 1, col - 1, list);
                     buildQueue.Enqueue(new int[2] { row + 1, col - 1 });
                 }
             }
@@ -286,28 +287,28 @@ public class BoardManager : MonoBehaviour
             {
                 if (IsValidBlock(row - 1, col)) // Up
                 {
-                   // ProcessBlock(row - 1, col, list);
+                    ProcessBlock(row - 1, col, list);
                     buildQueue.Enqueue(new int[2] { row - 1, col });
                 }
                 if (col < 7 && IsValidBlock(row - 1, col + 1)) // Up Right
                 {
-                  //  ProcessBlock(row - 1, col + 1, list);
+                    ProcessBlock(row - 1, col + 1, list);
                     buildQueue.Enqueue(new int[2] { row - 1, col + 1 });
                 }
                 if (col > 0 && IsValidBlock(row - 1, col - 1)) // Up Left
                 {
-                  //  ProcessBlock(row - 1, col - 1, list);
+                    ProcessBlock(row - 1, col - 1, list);
                     buildQueue.Enqueue(new int[2] { row - 1, col - 1 });
                 }
             }
             if (col > 0 && IsValidBlock(row, col - 1)) // Left
             {
-               // ProcessBlock(row, col - 1, list);
+                ProcessBlock(row, col - 1, list);
                 buildQueue.Enqueue(new int[2] { row, col - 1 });
             }
             if (col < 7 && IsValidBlock(row, col + 1)) // Right
             {
-                //ProcessBlock(row, col + 1, list);
+                ProcessBlock(row, col + 1, list);
                 buildQueue.Enqueue(new int[2] { row, col + 1 });
             }
 
@@ -322,9 +323,7 @@ public class BoardManager : MonoBehaviour
                 m--;
             }
 
-            int[] currPos = currentQueue.Peek();
-            ProcessBlock(currPos[0], currPos[1], list);
-            currentQueue.Dequeue();
+            int[] currPos = currentQueue.Dequeue();
             row = currPos[0];
             col = currPos[1];
 
@@ -333,18 +332,18 @@ public class BoardManager : MonoBehaviour
 
     /*
      * Process Block:
-     * Adds and marks the block coordinates as visited
+     * Adds and marks the block coordinates as visited. Helper function to make
+     * CalculateMovesFIFO() shorter.
      * Pre-condition:
      * The block coordinate given is valid.
      * Post-condition:
      * The coordinates are added into the given list and its block's visited
      * and movable attributes are now true.
      */
-            private void ProcessBlock(int row, int col, List<int[]> list)
+    private void ProcessBlock(int row, int col, List<int[]> list)
     {
         list.Add(new int[] { row, col });
         blocks[row, col].GetComponent<Block>().SetVisited(true);
-        blocks[row, col].GetComponent<Block>().SetMovable(true);
     }
 
     /*
@@ -359,10 +358,11 @@ public class BoardManager : MonoBehaviour
     }
 
 
-    private void RecolorBlockList(List<int[]> list)
+    private void SetBlockListMovable(List<int[]> list)
     {
         foreach (int[] pos in list)
         {
+            blocks[pos[0], pos[1]].GetComponent<Block>().SetMovable(true);
             blocks[pos[0], pos[1]].GetComponent<Block>().ChangeColor(Chess.Colors.W_MOVE);
         }
     }
@@ -376,7 +376,7 @@ public class BoardManager : MonoBehaviour
             d_block.GetComponent<Block>().SetVisited(false);
             d_block.GetComponent<Block>().SetMovable(false);
         }
-            
+
     }
 
     // Print out board state for debugging.

--- a/Fuzzy Logic Chess/Assets/Scripts/BoardManager.cs
+++ b/Fuzzy Logic Chess/Assets/Scripts/BoardManager.cs
@@ -210,6 +210,7 @@ public class BoardManager : MonoBehaviour
                 // Clicking.
                 if (Input.GetMouseButtonDown(0))
                 {
+                    
                     if (active_pieces[index[0], index[1]])
                     {
                         RefreshBlocks();
@@ -226,6 +227,10 @@ public class BoardManager : MonoBehaviour
                         MovePiece(selected_index, block.GetPosition());
                         selected_index = new int[2] { -1, -1 };
                     }
+                    else
+                    {
+                        RefreshBlocks();
+                    }
                 }
             }
         }
@@ -233,28 +238,18 @@ public class BoardManager : MonoBehaviour
 
     /*
      * Get Moves List:
+     * Uses Queues for breadth first search.  The queues are separated between
+     * the current generation (m) and the next generation (m-1).  When the 
+     * current generation is depleted, the next generation becomes the current
+     * generation and a new generation is created.
      * Post-condition:
      * Returns a list of coordinates of all movable blocks given an initial
      * position and available moves. 
      */
 
-    private List<int[]> GetMovesList(int row, int col, int moves)
+    private List<int[]> GetMovesList(int row, int col, int m)
     {
-        List<int[]> movesList = new List<int[]>();
-        CalculateMovesFIFO(row, col, moves, movesList);
-        return movesList;
-    }
-
-    /*
-     * Calculate Moves FIFO
-     * Uses Queues for breadth first search.  The queues are separated between
-     * the current generation (m) and the next generation (m-1).  When the 
-     * current generation is depleted, the next generation becomes the current
-     * generation and a new generation is created.
-     */
-
-    private void CalculateMovesFIFO(int row, int col, int m, List<int[]> list)
-    {
+        List<int[]> list = new List<int[]>();
         Queue<int[]> buildQueue = new Queue<int[]>();
         Queue<int[]> currentQueue = new Queue<int[]>();
         do
@@ -328,12 +323,13 @@ public class BoardManager : MonoBehaviour
             col = currPos[1];
 
         } while (m > 0);
+        return list;
     }
 
     /*
      * Process Block:
      * Adds and marks the block coordinates as visited. Helper function to make
-     * CalculateMovesFIFO() shorter.
+     * GetMovesList() shorter.
      * Pre-condition:
      * The block coordinate given is valid.
      * Post-condition:

--- a/Fuzzy Logic Chess/Assets/Scripts/Piece.cs
+++ b/Fuzzy Logic Chess/Assets/Scripts/Piece.cs
@@ -9,7 +9,7 @@ public class Piece : MonoBehaviour
 {
     private string p_name;
     private int n_moves;
-    int[] position = new int[2];
+    int[] position = new int[2]; // Do we need this? If we need this we have to change this every time the piece moves.
 
     private Vector3 destination;
     private bool moving = false;


### PR DESCRIPTION
Features
- Movable blocks can be returned as a List of int[] (in coordinate format) using GetMovesList().
- Pieces movements are restricted by their range.
- Clicking out of range will disselect the piece.


Changes
- Block class now has a visited and movable bool attribute.
- Modified the recursive search into a FIFO. Recursion is a depth first search which can create a situation where a series of visited blocks can choke a path from further searches. Think of it like a game of Snake where the snake's head can collide with its own body. Breadth first search ensures that the pattern of search radiates out from the origin.
- The search doesn't recolor the blocks on its own. SetBlockListMovable() takes a list of blocks, recolor them, and make them clickable.