### PR TITLE
Revised Pawn Movement and Attack Range

### DIFF
--- a/Fuzzy Logic Chess/Assets/Prefabs/b_king.prefab
+++ b/Fuzzy Logic Chess/Assets/Prefabs/b_king.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &5253854522087758188
+--- !u!1 &4524739827762841105
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,8 +8,8 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 4292022990871238122}
-  - component: {fileID: 674497362100856376}
+  - component: {fileID: 7596917580074985534}
+  - component: {fileID: 1346576819192963442}
   m_Layer: 0
   m_Name: b_king
   m_TagString: Untagged
@@ -17,27 +17,27 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &4292022990871238122
+--- !u!4 &7596917580074985534
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5253854522087758188}
+  m_GameObject: {fileID: 4524739827762841105}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.56, y: 3.94, z: 0}
+  m_LocalPosition: {x: 1.7, y: 3.96, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &674497362100856376
+--- !u!212 &1346576819192963442
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5253854522087758188}
+  m_GameObject: {fileID: 4524739827762841105}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -71,12 +71,12 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: -8593854955757590946, guid: 5d6dfc5e2a1ea1943a1b693d51fad64d, type: 3}
+  m_Sprite: {fileID: 900151559341354416, guid: 5d6dfc5e2a1ea1943a1b693d51fad64d, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 0.9, y: 0.84}
+  m_Size: {x: 0.79, y: 0.86}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1

--- a/Fuzzy Logic Chess/Assets/Prefabs/b_queen.prefab
+++ b/Fuzzy Logic Chess/Assets/Prefabs/b_queen.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &4524739827762841105
+--- !u!1 &5253854522087758188
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,8 +8,8 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 7596917580074985534}
-  - component: {fileID: 1346576819192963442}
+  - component: {fileID: 4292022990871238122}
+  - component: {fileID: 674497362100856376}
   m_Layer: 0
   m_Name: b_queen
   m_TagString: Untagged
@@ -17,27 +17,27 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &7596917580074985534
+--- !u!4 &4292022990871238122
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4524739827762841105}
+  m_GameObject: {fileID: 5253854522087758188}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1.7, y: 3.96, z: 0}
+  m_LocalPosition: {x: 0.56, y: 3.94, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &1346576819192963442
+--- !u!212 &674497362100856376
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4524739827762841105}
+  m_GameObject: {fileID: 5253854522087758188}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -71,12 +71,12 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: 900151559341354416, guid: 5d6dfc5e2a1ea1943a1b693d51fad64d, type: 3}
+  m_Sprite: {fileID: -8593854955757590946, guid: 5d6dfc5e2a1ea1943a1b693d51fad64d, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 0.79, y: 0.86}
+  m_Size: {x: 0.9, y: 0.84}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1

--- a/Fuzzy Logic Chess/Assets/Prefabs/w_king.prefab
+++ b/Fuzzy Logic Chess/Assets/Prefabs/w_king.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &3222774300546449537
+--- !u!1 &3009923334547300497
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,8 +8,8 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 8225953671629487029}
-  - component: {fileID: 7517468967957331953}
+  - component: {fileID: 27729496026035234}
+  - component: {fileID: 7639137965389972280}
   m_Layer: 0
   m_Name: w_king
   m_TagString: Untagged
@@ -17,27 +17,27 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &8225953671629487029
+--- !u!4 &27729496026035234
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3222774300546449537}
+  m_GameObject: {fileID: 3009923334547300497}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.55, y: 1.68, z: 0}
+  m_LocalPosition: {x: 1.66, y: 1.7, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &7517468967957331953
+--- !u!212 &7639137965389972280
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3222774300546449537}
+  m_GameObject: {fileID: 3009923334547300497}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -71,12 +71,12 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: 2733206427754647557, guid: 5d6dfc5e2a1ea1943a1b693d51fad64d, type: 3}
+  m_Sprite: {fileID: 8333762695492568133, guid: 5d6dfc5e2a1ea1943a1b693d51fad64d, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 0.91, y: 0.85}
+  m_Size: {x: 0.79, y: 0.86}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1

--- a/Fuzzy Logic Chess/Assets/Prefabs/w_queen.prefab
+++ b/Fuzzy Logic Chess/Assets/Prefabs/w_queen.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &3009923334547300497
+--- !u!1 &3222774300546449537
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,8 +8,8 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 27729496026035234}
-  - component: {fileID: 7639137965389972280}
+  - component: {fileID: 8225953671629487029}
+  - component: {fileID: 7517468967957331953}
   m_Layer: 0
   m_Name: w_queen
   m_TagString: Untagged
@@ -17,27 +17,27 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &27729496026035234
+--- !u!4 &8225953671629487029
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3009923334547300497}
+  m_GameObject: {fileID: 3222774300546449537}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1.66, y: 1.7, z: 0}
+  m_LocalPosition: {x: 0.55, y: 1.68, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &7639137965389972280
+--- !u!212 &7517468967957331953
 SpriteRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3009923334547300497}
+  m_GameObject: {fileID: 3222774300546449537}
   m_Enabled: 1
   m_CastShadows: 0
   m_ReceiveShadows: 0
@@ -71,12 +71,12 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: 8333762695492568133, guid: 5d6dfc5e2a1ea1943a1b693d51fad64d, type: 3}
+  m_Sprite: {fileID: 2733206427754647557, guid: 5d6dfc5e2a1ea1943a1b693d51fad64d, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 0.79, y: 0.86}
+  m_Size: {x: 0.91, y: 0.85}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1

--- a/Fuzzy Logic Chess/Assets/Scripts/BoardManager.cs
+++ b/Fuzzy Logic Chess/Assets/Scripts/BoardManager.cs
@@ -10,7 +10,7 @@ using UnityEngine;
 
 public class BoardManager : MonoBehaviour
 {
-    public GameManager gm; 
+    public GameManager gm;
 
     // Clickable Game Object assigned in unity. 
     public GameObject block;
@@ -49,7 +49,7 @@ public class BoardManager : MonoBehaviour
     private void Start()
     {
         // Layout blocks Grid, 8x8
-        bool flip = false;
+        bool flip = true;
         int index = 0;
         for (int i = 0; i < blocks.GetLength(0); i++)
         {
@@ -299,7 +299,7 @@ public class BoardManager : MonoBehaviour
         // Update the pieces game object array. 
         pieces[to[0], to[1]] = pieces[from[0], from[1]];
         pieces[from[0], from[1]] = null;
-   
+
         selected_piece = null;
         input_requested = false;
 
@@ -320,9 +320,40 @@ public class BoardManager : MonoBehaviour
         {
             int[] index = piece.position;
             blocks[index[0], index[1]].ChangeColor(Color.cyan);
-        }    
+        }
 
         // Possibly return pieces for AI. 
+    }
+
+    /*
+     * Get Attackable List:
+     * Post-condition:
+     * Returns a list of coordinates of all adjacent blocks with enemy
+     * pieces. Rooks have a range of 2. 
+     */
+    private List<int[]> GetAttackableList(int row, int col)
+    {
+        List<int[]> newList = new List<int[]>();
+        bool isWhitePiece = pieces[row, col].GetTeam().Equals("white");
+        int range = 1;
+        if (pieces[row, col].GetPName().Equals("w_rook") || pieces[row, col].GetPName().Equals("b_rook"))
+            range = pieces[row, col].GetNumberOfMoves(); ;
+        int west = Mathf.Max(0, row - range);
+        int east = Mathf.Min(7, row + range);
+        int north = Mathf.Max(0, col - range);
+        int south = Mathf.Min(7, col + range);
+        for (int i = west; i <= east; i++)
+        {
+            for (int j = north; j <= south; j++)
+            {
+                if (pieces[i, j])
+                {
+                    if (pieces[i, j].GetTeam().Equals("white") != isWhitePiece)
+                        newList.Add(new int[] { i, j });
+                }
+            }
+        }
+        return newList;
     }
 
     /*
@@ -335,7 +366,6 @@ public class BoardManager : MonoBehaviour
      * Returns a list of coordinates of all movable blocks given an initial
      * position and available moves. 
      */
-
     private List<int[]> GetMovesList(int row, int col, int m)
     {
         List<int[]> list = new List<int[]>();
@@ -343,13 +373,12 @@ public class BoardManager : MonoBehaviour
         Queue<int[]> currentQueue = new Queue<int[]>();
         do
         {
-
             /* NOTE: If you can express the validation for the adjacent blocks better
              * or more optimized, please feel free.  All adjacent blocks needs to be 
              * validated and passed to ProcessBlock() before any of them can be
              * dequeued.  Can't ProcessBlock() while Dequeueing.
              */
-            if (row < 7 && pieces[row,col].GetPName() != "b_pawn")
+            if (row < 7 && pieces[row, col].GetPName() != "b_pawn")
             {
                 if (IsValidBlock(row + 1, col)) // Down
                 {
@@ -463,6 +492,14 @@ public class BoardManager : MonoBehaviour
         }
     }
 
+    private void SetBlockListAttackable(List<int[]> list, string team)
+    {
+        foreach (int[] pos in list)
+        {
+            blocks[pos[0], pos[1]].ChangeColor(team == "white" ? Chess.Colors.W_ATTACK : Chess.Colors.B_ATTACK);
+        }
+    }
+
     // List of all directions to simplify things.
     private int[,] dir = new int[,] { { 0, 1 }, { 1, 0 }, { 0, -1 }, { -1, 0 }, { -1, 1 }, { 1, -1 }, { 1, 1 }, { -1, -1 } };
 
@@ -527,7 +564,7 @@ public class BoardManager : MonoBehaviour
         }
 
         // Highlight destination.
-        blocks[path[path.Count-1][0], path[path.Count-1][1]].ChangeColor(Color.cyan);
+        blocks[path[path.Count - 1][0], path[path.Count - 1][1]].ChangeColor(Color.cyan);
 
         return positions;
     }
@@ -547,7 +584,7 @@ public class BoardManager : MonoBehaviour
     {
         foreach (Piece piece in pieces)
         {
-            if (piece) piece.ResetPiece();        
+            if (piece) piece.ResetPiece();
         }
     }
 

--- a/Fuzzy Logic Chess/Assets/Scripts/Chess.cs
+++ b/Fuzzy Logic Chess/Assets/Scripts/Chess.cs
@@ -55,6 +55,6 @@ public class Chess : MonoBehaviour
         public static Color W_ATTACK = Color.red;
 
         public static Color B_SELECTED = Color.cyan;
-        public static Color B_ATTACK = Color.cyan;
+        public static Color B_ATTACK = Color.red;
     }
 }


### PR DESCRIPTION
What's New:
- GetAttackableList() returns a list of all adjacent blocks with enemy pieces.  Rooks have a range of 2.
- SetBlockListAttackable() function for recoloring the blocks red.
- Switched the King's and Queen's sprites
- B_ATTACK set to red.